### PR TITLE
Allow the joi to accept dot versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const Parser = require('./parser')
 const Warning = require('./warning')
 
 const dockerComposeFileSchema = Joi.object({
-  version: Joi.string().regex(/^2(\.\d*)$/).required(),
+  version: Joi.string().regex(/^2(\.\d*)?$/).required(),
   services: Joi.object().required()
 }).unknown().required()
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const Parser = require('./parser')
 const Warning = require('./warning')
 
 const dockerComposeFileSchema = Joi.object({
-  version: Joi.string().valid('2').required(),
+  version: Joi.string().regex(/^2(\.\d*)$/).required(),
   services: Joi.object().required()
 }).unknown().required()
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const DockerComposeParser = require('index')
+
+describe('index', () => {
+  describe('#_parseDockerComposeFile', () => {
+    let yml
+
+    it('should return fine with version 2', (done) => {
+      yml = `
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - "7890:7890"
+`
+      DockerComposeParser._parseDockerComposeFile(yml)
+        .asCallback(done)
+    })
+
+    it('should return fine with version 2.0', (done) => {
+      yml = `
+version: '2.0'
+services:
+  web:
+    build: .
+    ports:
+      - "7890:7890"
+`
+      DockerComposeParser._parseDockerComposeFile(yml)
+        .asCallback(done)
+    })
+
+    it('should fail with version 3', (done) => {
+      yml = `
+version: '3.0'
+services:
+  web:
+    build: .
+    ports:
+      - "7890:7890"
+`
+      DockerComposeParser._parseDockerComposeFile(yml)
+        .then(() => {
+          done(new Error('Should have failed'))
+        })
+        .catch(() => done())
+    })
+    it('should fail with version 2.a', (done) => {
+      yml = `
+version: '2.a'
+services:
+  web:
+    build: .
+    ports:
+      - "7890:7890"
+`
+      DockerComposeParser._parseDockerComposeFile(yml)
+        .then(() => { done(new Error('Should have failed')) })
+        .catch(() => done())
+    })
+  })
+})


### PR DESCRIPTION
Switching from valid to a regex that works for 2 and 2.X