### PR TITLE
prioritize builds over github links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "test/repos/compose-test-repo-6.2"]
 	path = test/repos/compose-test-repo-6.2
 	url = git@github.com:RunnableTest/compose-test-repo-6.2.git
+[submodule "test/repos/compose-test-repo-6.3"]
+	path = test/repos/compose-test-repo-6.3
+	url = git@github.com:RunnableTest/compose-test-repo-6.3.git

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ In order to run tests locally you also need to pull submodules. The easiest way 
   git clone --recursive git@github.com:Runnable/octobear.git
 ```
 
+To update them, use
+```
+git submodule update --init --recursive
+```
+
 Also, in order to run tests locally you'll need populate the environment variables in `configs/.env`. We suggest adding them to `configs/.env.test`.
 
 There are three types of tests:

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ const Mapper = require('./mapper')
 const Parser = require('./parser')
 const Warning = require('./warning')
 
+const GITHUB_REGEX = /github\.com/
+
 const dockerComposeFileSchema = Joi.object({
   version: Joi.string().regex(/^(2|3)(\.\d*)?$/).required(),
   services: Joi.object().required()
@@ -228,15 +230,29 @@ module.exports = class DockerComposeParser {
 
   /**
    * Get main container for docker compose cluster. Picks the first container
-   * with a `build` property.
+   * with a `build` property that isn't from github, unless it only has github, then it picks that first one
    *
    * @param {Object<Key:Service>} services - Object with service names as keys and service objects as values
-   * @returns {String}
+   * @returns {String||Undefined} Returns the key name of the main instance, or undefined if it's not there
    */
   static _getMainName (services) {
-    return Object.keys(services)
-      .map(key => services[key].build && key)
-      .find(key => !!key)
+    const buildLists = Object.keys(services)
+      .filter(key => !!services[key].build)
+      .reduce((buildLists, key) => {
+        const buildObj = services[key].build
+        if (typeof (buildObj) === 'string' && GITHUB_REGEX.test(buildObj)) {
+          buildLists.links.push(key)
+        } else {
+          buildLists.builds.push(key)
+        }
+        return buildLists
+      }, { builds: [], links: [] })
+
+    if (buildLists.builds.length) {
+      return buildLists.builds[0]
+    } else if (buildLists.links.length) {
+      return buildLists.links[0]
+    }
   }
 
   /**

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -651,4 +651,26 @@ describe('6. Build GitHub repos', () => {
       expect(services[0].instance.ports[0]).to.equal(7890)
     })
   })
+
+  describe('6.3: Picking the right master with github', () => {
+    const repositoryName = 'compose-test-repo-6.3'
+    const { dockerComposeFileString } = getDockerFile(repositoryName)
+    let services
+
+    before(() => {
+      return parse({ dockerComposeFileString, repositoryName, userContentDomain, ownerUsername, scmDomain })
+        .then(({ results: servicesResults }) => {
+          services = servicesResults
+        })
+    })
+
+    it('should return two instances', () => {
+      expect(services).to.have.lengthOf(2)
+    })
+
+    it('should set api to isMain', () => {
+      const api = services.find(service => service.metadata.name === 'api')
+      expect(api).to.have.deep.property('metadata.isMain', true)
+    })
+  })
 })

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -60,6 +60,47 @@ services:
     })
   })
 
+  describe('#_getMainName', () => {
+    let services
+    beforeEach(() => {
+      services = {
+        web: {
+          build: 'https://github.com/Runnable/test-compose'
+        },
+        api: {
+          build: 'git@github.com/Runnable/test-compose'
+        },
+        api2: {
+          build: '.'
+        },
+        database: {
+          image: 'asdasdasd'
+        },
+        web2: {
+          build: {
+            context: 'asdassad'
+          }
+        }
+      }
+    })
+
+    it('should pick api2 as main', done => {
+      expect(DockerComposeParser._getMainName(services)).to.equal('api2')
+      done()
+    })
+    it('should pick web2 if api2 isn\'t there', done => {
+      delete services.api2
+      expect(DockerComposeParser._getMainName(services)).to.equal('web2')
+      done()
+    })
+    it('should pick the first github if api2 and web2 aren\'t there', done => {
+      delete services.api2
+      delete services.web2
+      expect(DockerComposeParser._getMainName(services)).to.equal('web')
+      done()
+    })
+  })
+
   describe('#populateENVsFromFiles', () => {
     let services
     let envFilesMap


### PR DESCRIPTION
modify the getMainName to consider github links secondary to builds with a path in them.

Adding unit tests to make sure the logic is sound