### PR TITLE
Fix url parse

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,7 @@
 'use strict'
 const path = require('path')
 const url = require('url')
+const TRAILING_SLASH_REGEX = /\/$/
 
 module.exports = class Parser {
 
@@ -223,6 +224,7 @@ FROM ${image}`
 
     return env.map(env => {
       const match = env.match(/([\w]*)=(.*)$/)
+      const trailingSlashMatch = env.match(TRAILING_SLASH_REGEX)
       if (match && match[2]) {
         const envKey = match[1]
         const envValue = match[2]
@@ -234,7 +236,7 @@ FROM ${image}`
         const parsedUrl = url.parse(envValue)
         if (parsedUrl.hostname && links.indexOf(parsedUrl.hostname) > -1) {
           const newHost = hostnames[parsedUrl.hostname]
-          const newUrl = url.format({
+          let newUrl = url.format({
             protocol: parsedUrl.protocol,
             slashes: parsedUrl.slashes,
             auth: parsedUrl.auth,
@@ -246,6 +248,9 @@ FROM ${image}`
             pathname: parsedUrl.pathname,
             path: parsedUrl.path
           })
+          if (!trailingSlashMatch) {
+            newUrl = newUrl.replace(TRAILING_SLASH_REGEX, '')
+          }
           return `${envKey}=${newUrl}`
         }
         // Match host:port

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -292,5 +292,13 @@ describe('Parser', () => {
       const result = Parser.envReplacementParser({ env, hostnames, links: ['rams_db'] })
       expect(result[0]).to.equal(`DB_CONNECTION_STRING=postgresql://uber_db:uber_db@${newHost}:5432/uber_db`)
     })
+
+    it('should not append an trailing slash in http URLs', () => {
+      const env = ['SEARCH_URL=http://search:9200']
+      const newHost = 'compose-test-search-staging-runnabletest.runnable.ninja'
+      const hostnames = { search: newHost }
+      const result = Parser.envReplacementParser({ env, hostnames, links: ['search'] })
+      expect(result[0]).to.equal(`SEARCH_URL=http://${newHost}:9200`)
+    })
   })
 })

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -293,12 +293,20 @@ describe('Parser', () => {
       expect(result[0]).to.equal(`DB_CONNECTION_STRING=postgresql://uber_db:uber_db@${newHost}:5432/uber_db`)
     })
 
-    it('should not append an trailing slash in http URLs', () => {
+    it('should not append a trailing slash in http URLs', () => {
       const env = ['SEARCH_URL=http://search:9200']
       const newHost = 'compose-test-search-staging-runnabletest.runnable.ninja'
       const hostnames = { search: newHost }
       const result = Parser.envReplacementParser({ env, hostnames, links: ['search'] })
       expect(result[0]).to.equal(`SEARCH_URL=http://${newHost}:9200`)
+    })
+
+    it('should not remove a trailing slash that already exists', () => {
+      const env = ['SEARCH_URL=http://search:9200/']
+      const newHost = 'compose-test-search-staging-runnabletest.runnable.ninja'
+      const hostnames = { search: newHost }
+      const result = Parser.envReplacementParser({ env, hostnames, links: ['search'] })
+      expect(result[0]).to.equal(`SEARCH_URL=http://${newHost}:9200/`)
     })
   })
 })

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -293,20 +293,16 @@ describe('Parser', () => {
       expect(result[0]).to.equal(`DB_CONNECTION_STRING=postgresql://uber_db:uber_db@${newHost}:5432/uber_db`)
     })
 
-    it('should not append a trailing slash in http URLs', () => {
-      const env = ['SEARCH_URL=http://search:9200']
-      const newHost = 'compose-test-search-staging-runnabletest.runnable.ninja'
-      const hostnames = { search: newHost }
-      const result = Parser.envReplacementParser({ env, hostnames, links: ['search'] })
-      expect(result[0]).to.equal(`SEARCH_URL=http://${newHost}:9200`)
-    })
-
-    it('should not remove a trailing slash that already exists', () => {
-      const env = ['SEARCH_URL=http://search:9200/']
-      const newHost = 'compose-test-search-staging-runnabletest.runnable.ninja'
-      const hostnames = { search: newHost }
-      const result = Parser.envReplacementParser({ env, hostnames, links: ['search'] })
-      expect(result[0]).to.equal(`SEARCH_URL=http://${newHost}:9200/`)
+    it('should not append a trailing slash in http URLs or remove an existing one', () => {
+      const env = ['SEARCH_URL=http://search:9200', 'DB_URL=postgres://db:5432', 'ANOTHER_SEARCH=http://search2:9200/']
+      const newSearchHost = 'compose-test-search-staging-runnabletest.runnable.ninja'
+      const newDbHost = 'compose-test-db-staging-runnabletest.runnable.ninja'
+      const newSearch2Host = 'compose-test-search2-staging-runnabletest.runnable.ninja'
+      const hostnames = { search: newSearchHost, db: newDbHost, search2: newSearch2Host }
+      const result = Parser.envReplacementParser({ env, hostnames, links: ['search', 'db', 'search2'] })
+      expect(result[0]).to.equal(`SEARCH_URL=http://${newSearchHost}:9200`)
+      expect(result[1]).to.equal(`DB_URL=postgres://${newDbHost}:5432`)
+      expect(result[2]).to.equal(`ANOTHER_SEARCH=http://${newSearch2Host}:9200/`)
     })
   })
 })


### PR DESCRIPTION
url.Parse appends `/` to http URLs. This can break users connection strings if they are not expecting the additional `/`. We now check for these added `/`.